### PR TITLE
Add prompts specifying "VR" or "FIP" before rig pickers

### DIFF
--- a/main.py
+++ b/main.py
@@ -65,7 +65,9 @@ async def experiment(launcher: Launcher) -> None:
     input_trainer_state_path = launcher.save_temp_model(trainer_state)
 
     # Fetch rig settings
+    logger.info("Pick VR Foraging rig...")
     rig = picker.pick_rig(AindVrForagingRig)
+    logger.info("Pick FIP rig...")
     fip_rig = fip_picker.pick_rig(aind_physiology_fip.rig.AindPhysioFipRig)
 
     # Post-fetching modifications


### PR DESCRIPTION
Add messages "Pick VR rig" or "Pick FIP rig" before pickers in launcher to specify which is being requested